### PR TITLE
Fix/code block annotations

### DIFF
--- a/src/ast-types/smdast/annotations.ts
+++ b/src/ast-types/smdast/annotations.ts
@@ -1,9 +1,9 @@
-export type ThemeType = 'info' | 'warning' | 'danger' | 'success';
+import { Dictionary } from '@stoplight/types';
 
 export type AnnotationType = 'tab' | 'tab-end';
 
-export interface IAnnotations {
-  type?: AnnotationType;
-  theme?: ThemeType;
-  title?: string;
+export type ThemeType = 'info' | 'warning' | 'danger' | 'success';
+
+export interface IAnnotations<T extends Dictionary<any> = {}> {
+  annotations?: T;
 }

--- a/src/ast-types/smdast/blockquote.ts
+++ b/src/ast-types/smdast/blockquote.ts
@@ -1,7 +1,0 @@
-import { IBlockquote as MdastBlockquote } from '../mdast';
-
-import { IAnnotations } from './annotations';
-
-export interface IBlockquote extends MdastBlockquote {
-  annotations?: IAnnotations;
-}

--- a/src/ast-types/smdast/index.ts
+++ b/src/ast-types/smdast/index.ts
@@ -1,9 +1,12 @@
+import { Dictionary } from '@stoplight/types';
+import * as MDASst from '../mdast';
+import { IAnnotations } from './annotations';
+
 export {
   IThematicBreak,
   ITable,
   ITableCell,
   ITableRow,
-  ICode,
   IDefinition,
   IDelete,
   IEmphasis,
@@ -20,7 +23,9 @@ export {
   IList,
   IListItem,
 } from '../mdast';
-export * from './blockquote';
 export * from './element';
 export * from './annotations';
 export * from './tab';
+
+export interface IBlockquote<T extends Dictionary<any> = {}> extends IAnnotations<T>, MDASst.IBlockquote {}
+export interface ICode<T extends Dictionary<any> = {}> extends IAnnotations<T>, MDASst.ICode {}

--- a/src/ast-types/smdast/tab.ts
+++ b/src/ast-types/smdast/tab.ts
@@ -1,5 +1,5 @@
+import { Dictionary } from '@stoplight/types';
 import * as Unist from 'unist';
-
 import { IAnnotations } from './annotations';
 
 export interface ITabContainer extends Unist.Parent {
@@ -7,7 +7,6 @@ export interface ITabContainer extends Unist.Parent {
   children: Unist.Node[];
 }
 
-export interface ITab extends Unist.Parent {
+export interface ITab<T extends Dictionary<any> = { type?: string }> extends IAnnotations<T>, Unist.Parent {
   type: 'tab';
-  annotations?: IAnnotations;
 }

--- a/src/reader/__tests__/reader.spec.ts
+++ b/src/reader/__tests__/reader.spec.ts
@@ -1,10 +1,14 @@
 import { Reader } from '../reader';
 
 describe('Reader', () => {
+  let mdReader: Reader;
+
+  beforeEach(() => {
+    mdReader = new Reader();
+  });
+
   describe('fromLang', () => {
     test('parses a line of text', () => {
-      const mdReader = new Reader();
-
       const tree = mdReader.fromLang(`A line of text.`);
 
       expect(tree).toEqual({
@@ -62,8 +66,6 @@ describe('Reader', () => {
     });
 
     test('parses text with marks', () => {
-      const mdReader = new Reader();
-
       const tree = mdReader.fromLang(`A line of text with **_nested_ marks** in a paragraph.`);
 
       expect(tree).toEqual({
@@ -210,8 +212,6 @@ describe('Reader', () => {
 
   describe('toSpec', () => {
     test('captures annotations for code blocks', () => {
-      const mdReader = new Reader();
-
       const markdown = `<!--
 title: "My code snippet"
 lineNumbers: false

--- a/src/reader/__tests__/reader.spec.ts
+++ b/src/reader/__tests__/reader.spec.ts
@@ -1,206 +1,239 @@
 import { Reader } from '../reader';
 
-const mdReader = new Reader();
+describe('Reader', () => {
+  describe('fromLang', () => {
+    test('parses a line of text', () => {
+      const mdReader = new Reader();
 
-describe('doc-parse', () => {
-  test('parses a line of text', () => {
-    const tree = mdReader.fromLang(`A line of text.`);
+      const tree = mdReader.fromLang(`A line of text.`);
 
-    expect(tree).toEqual({
-      type: 'root',
-      children: [
-        {
-          type: 'paragraph',
-          children: [
-            {
-              type: 'text',
-              value: 'A line of text.',
-              position: {
-                start: {
-                  line: 1,
-                  column: 1,
-                  offset: 0,
+      expect(tree).toEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'text',
+                value: 'A line of text.',
+                position: {
+                  start: {
+                    line: 1,
+                    column: 1,
+                    offset: 0,
+                  },
+                  end: {
+                    line: 1,
+                    column: 16,
+                    offset: 15,
+                  },
+                  indent: [],
                 },
-                end: {
-                  line: 1,
-                  column: 16,
-                  offset: 15,
-                },
-                indent: [],
               },
+            ],
+            position: {
+              start: {
+                line: 1,
+                column: 1,
+                offset: 0,
+              },
+              end: {
+                line: 1,
+                column: 16,
+                offset: 15,
+              },
+              indent: [],
             },
-          ],
-          position: {
-            start: {
-              line: 1,
-              column: 1,
-              offset: 0,
-            },
-            end: {
-              line: 1,
-              column: 16,
-              offset: 15,
-            },
-            indent: [],
+          },
+        ],
+        position: {
+          start: {
+            line: 1,
+            column: 1,
+            offset: 0,
+          },
+          end: {
+            line: 1,
+            column: 16,
+            offset: 15,
           },
         },
-      ],
-      position: {
-        start: {
-          line: 1,
-          column: 1,
-          offset: 0,
+      });
+    });
+
+    test('parses text with marks', () => {
+      const mdReader = new Reader();
+
+      const tree = mdReader.fromLang(`A line of text with **_nested_ marks** in a paragraph.`);
+
+      expect(tree).toEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'text',
+                value: 'A line of text with ',
+                position: {
+                  start: {
+                    line: 1,
+                    column: 1,
+                    offset: 0,
+                  },
+                  end: {
+                    line: 1,
+                    column: 21,
+                    offset: 20,
+                  },
+                  indent: [],
+                },
+              },
+              {
+                type: 'strong',
+                children: [
+                  {
+                    type: 'emphasis',
+                    children: [
+                      {
+                        type: 'text',
+                        value: 'nested',
+                        position: {
+                          start: {
+                            line: 1,
+                            column: 24,
+                            offset: 23,
+                          },
+                          end: {
+                            line: 1,
+                            column: 30,
+                            offset: 29,
+                          },
+                          indent: [],
+                        },
+                      },
+                    ],
+                    position: {
+                      start: {
+                        line: 1,
+                        column: 23,
+                        offset: 22,
+                      },
+                      end: {
+                        line: 1,
+                        column: 31,
+                        offset: 30,
+                      },
+                      indent: [],
+                    },
+                  },
+                  {
+                    type: 'text',
+                    value: ' marks',
+                    position: {
+                      start: {
+                        line: 1,
+                        column: 31,
+                        offset: 30,
+                      },
+                      end: {
+                        line: 1,
+                        column: 37,
+                        offset: 36,
+                      },
+                      indent: [],
+                    },
+                  },
+                ],
+                position: {
+                  start: {
+                    line: 1,
+                    column: 21,
+                    offset: 20,
+                  },
+                  end: {
+                    line: 1,
+                    column: 39,
+                    offset: 38,
+                  },
+                  indent: [],
+                },
+              },
+              {
+                type: 'text',
+                value: ' in a paragraph.',
+                position: {
+                  start: {
+                    line: 1,
+                    column: 39,
+                    offset: 38,
+                  },
+                  end: {
+                    line: 1,
+                    column: 55,
+                    offset: 54,
+                  },
+                  indent: [],
+                },
+              },
+            ],
+            position: {
+              start: {
+                line: 1,
+                column: 1,
+                offset: 0,
+              },
+              end: {
+                line: 1,
+                column: 55,
+                offset: 54,
+              },
+              indent: [],
+            },
+          },
+        ],
+        position: {
+          start: {
+            line: 1,
+            column: 1,
+            offset: 0,
+          },
+          end: {
+            line: 1,
+            column: 55,
+            offset: 54,
+          },
         },
-        end: {
-          line: 1,
-          column: 16,
-          offset: 15,
-        },
-      },
+      });
     });
   });
 
-  test('parses text with marks', () => {
-    const tree = mdReader.fromLang(`A line of text with **_nested_ marks** in a paragraph.`);
+  describe('toSpec', () => {
+    test('captures annotations for code blocks', () => {
+      const mdReader = new Reader();
 
-    expect(tree).toEqual({
-      type: 'root',
-      children: [
-        {
-          type: 'paragraph',
-          children: [
-            {
-              type: 'text',
-              value: 'A line of text with ',
-              position: {
-                start: {
-                  line: 1,
-                  column: 1,
-                  offset: 0,
-                },
-                end: {
-                  line: 1,
-                  column: 21,
-                  offset: 20,
-                },
-                indent: [],
-              },
-            },
-            {
-              type: 'strong',
-              children: [
-                {
-                  type: 'emphasis',
-                  children: [
-                    {
-                      type: 'text',
-                      value: 'nested',
-                      position: {
-                        start: {
-                          line: 1,
-                          column: 24,
-                          offset: 23,
-                        },
-                        end: {
-                          line: 1,
-                          column: 30,
-                          offset: 29,
-                        },
-                        indent: [],
-                      },
-                    },
-                  ],
-                  position: {
-                    start: {
-                      line: 1,
-                      column: 23,
-                      offset: 22,
-                    },
-                    end: {
-                      line: 1,
-                      column: 31,
-                      offset: 30,
-                    },
-                    indent: [],
-                  },
-                },
-                {
-                  type: 'text',
-                  value: ' marks',
-                  position: {
-                    start: {
-                      line: 1,
-                      column: 31,
-                      offset: 30,
-                    },
-                    end: {
-                      line: 1,
-                      column: 37,
-                      offset: 36,
-                    },
-                    indent: [],
-                  },
-                },
-              ],
-              position: {
-                start: {
-                  line: 1,
-                  column: 21,
-                  offset: 20,
-                },
-                end: {
-                  line: 1,
-                  column: 39,
-                  offset: 38,
-                },
-                indent: [],
-              },
-            },
-            {
-              type: 'text',
-              value: ' in a paragraph.',
-              position: {
-                start: {
-                  line: 1,
-                  column: 39,
-                  offset: 38,
-                },
-                end: {
-                  line: 1,
-                  column: 55,
-                  offset: 54,
-                },
-                indent: [],
-              },
-            },
-          ],
-          position: {
-            start: {
-              line: 1,
-              column: 1,
-              offset: 0,
-            },
-            end: {
-              line: 1,
-              column: 55,
-              offset: 54,
-            },
-            indent: [],
+      const markdown = `<!--
+title: "My code snippet"
+lineNumbers: false
+highlightLines: [[1,2], [4,5]]
+    -->
+    
+    \`\`\`javascript
+    var x = true;
+    \`\`\` `;
+
+      const tree = mdReader.toSpec(mdReader.fromLang(markdown));
+
+      expect(tree).toHaveProperty('children', [
+        expect.objectContaining({
+          type: 'code',
+          annotations: {
+            title: 'My code snippet',
+            lineNumbers: false,
+            highlightLines: [[1, 2], [4, 5]],
           },
-        },
-      ],
-      position: {
-        start: {
-          line: 1,
-          column: 1,
-          offset: 0,
-        },
-        end: {
-          line: 1,
-          column: 55,
-          offset: 54,
-        },
-      },
+        }),
+      ]);
     });
   });
 });

--- a/src/reader/transformers/to-spec.ts
+++ b/src/reader/transformers/to-spec.ts
@@ -1,9 +1,10 @@
+import { Dictionary } from '@stoplight/types';
 import * as yaml from 'js-yaml';
 import * as Unist from 'unist';
 import * as Mdast from '../../ast-types/mdast';
 import * as SMdast from '../../ast-types/smdast';
 
-function captureAnnotations(node: Unist.Node | undefined): SMdast.IAnnotations {
+function captureAnnotations<T extends Dictionary<any>>(node: Unist.Node | undefined): T | {} {
   if (!node || !node.value) {
     return {};
   }
@@ -72,11 +73,11 @@ export const toSpec = (root: Mdast.IRoot): SMdast.IRoot => {
     // collect annotations, if this is an html node
     const anno = captureAnnotations(node);
 
-    if (anno.type) {
+    if ('type' in anno) {
       const { type } = anno;
 
       // remove type annotation so that we can pass the annotation object around wholesale
-      delete anno.type;
+      delete (anno as Partial<{ type: SMdast.AnnotationType }>).type;
 
       if (type === 'tab') {
         const { children } = tabPlaceholder;

--- a/src/reader/transformers/to-spec.ts
+++ b/src/reader/transformers/to-spec.ts
@@ -25,21 +25,12 @@ function captureAnnotations(node: Unist.Node | undefined): SMdast.IAnnotations {
   return {};
 }
 
-function processBlockquote(node: Mdast.IBlockquote, anno: SMdast.IAnnotations): SMdast.IBlockquote {
-  return {
-    type: 'blockquote',
-    annotations: {
-      ...anno,
-    },
-    children: node.children,
-  };
-}
-
-function processNode(node: Unist.Node, anno: SMdast.IAnnotations | null): Unist.Node {
-  const { type } = node;
-
-  if (type === 'blockquote' && anno) {
-    return processBlockquote(node as Mdast.IBlockquote, anno);
+function processNode(node: Unist.Node, annotations: SMdast.IAnnotations | null): Unist.Node {
+  if (annotations) {
+    return {
+      ...node,
+      annotations,
+    };
   }
 
   return node;
@@ -138,7 +129,7 @@ export const toSpec = (root: Mdast.IRoot): SMdast.IRoot => {
       processed.push(processNode(next, anno));
       skipNext = true;
     } else {
-      processed.push(processNode(node, {}));
+      processed.push(processNode(node, null));
     }
   }
 

--- a/src/reader/transformers/to-spec.ts
+++ b/src/reader/transformers/to-spec.ts
@@ -25,7 +25,7 @@ function captureAnnotations(node: Unist.Node | undefined): SMdast.IAnnotations {
   return {};
 }
 
-function processNode(node: Unist.Node, annotations: SMdast.IAnnotations | null): Unist.Node {
+function processNode(node: Unist.Node, annotations?: SMdast.IAnnotations): Unist.Node {
   if (annotations) {
     return {
       ...node,
@@ -129,7 +129,7 @@ export const toSpec = (root: Mdast.IRoot): SMdast.IRoot => {
       processed.push(processNode(next, anno));
       skipNext = true;
     } else {
-      processed.push(processNode(node, null));
+      processed.push(processNode(node));
     }
   }
 


### PR DESCRIPTION
You can see lineNumbers in action [here](https://github.com/stoplightio/markdown-viewer/pull/5/files)

If we take a look at smdast types, we can clearly see annotations are limted.
Is there any reason for that? Perhaps, we shouldn't be adding annotations to each node?

https://github.com/stoplightio/markdown/blob/b4e430acaa085557a5dd4e2d5fec1910011b9b17/src/ast-types/smdast/annotations.ts#L1#L9
