### PR TITLE
fix: always attach annotations to next block node

### DIFF
--- a/src/reader/__tests__/fixtures/markdown/blockquote.md
+++ b/src/reader/__tests__/fixtures/markdown/blockquote.md
@@ -4,15 +4,11 @@
 > * asterisk 2
 > * asterisk 3
 
-<!--
-theme: danger
--->
+<!-- theme: danger -->
 
 > This is a callout with **danger** as the theme
 
-<!--
-theme: info
--->
+<!-- theme: info -->
 
 > This is a callout with **info** as the theme
 

--- a/src/reader/__tests__/fixtures/markdown/code.md
+++ b/src/reader/__tests__/fixtures/markdown/code.md
@@ -1,0 +1,47 @@
+## Code Blocks
+
+A smd code block is md code fence with an optional annotation to tweak the presentation of the code block.
+
+<!--
+title: Fibonacci In Javascript
+lineNumbers: false
+highlightLines:
+  - - 1
+    - 2
+  - - 4
+    - 5
+-->
+
+```javascript
+function fibonacci(num){
+  var a = 1, b = 0, temp;
+
+  while (num >= 0){
+    temp = a;
+    a = a + b;
+    b = temp;
+    num--;
+  }
+
+  return b;
+}
+```
+
+## JSON Schema
+
+A smd json schema block is a smd code block with the `json_schema` language tag. The contents of the code fence should
+be the json schema object to be rendered.
+
+<!-- type: json_schema -->
+
+```json
+{
+  "title": "User",
+  "type": "object",
+    "properties": {
+    "name": {
+      "type": "string"
+    }
+  }
+}
+```

--- a/src/reader/__tests__/fixtures/markdown/tabs.md
+++ b/src/reader/__tests__/fixtures/markdown/tabs.md
@@ -27,6 +27,4 @@ type: tab
 
 And another one
 
-<!--
-type: tab-end
--->
+<!-- type: tab-end -->

--- a/src/reader/transformers/to-spec.ts
+++ b/src/reader/transformers/to-spec.ts
@@ -80,9 +80,6 @@ export const toSpec = (root: Mdast.IRoot): SMdast.IRoot => {
     if ('type' in anno) {
       const { type } = anno;
 
-      // remove type annotation so that we can pass the annotation object around wholesale
-      delete (anno as Partial<{ type: SMdast.AnnotationType }>).type;
-
       if (type === 'tab') {
         const { children } = tabPlaceholder;
 
@@ -103,6 +100,8 @@ export const toSpec = (root: Mdast.IRoot): SMdast.IRoot => {
         }
 
         tabPlaceholder.children = children;
+
+        continue;
       } else if (type === 'tab-end') {
         // finalize tabContainer
         processed.push(tabPlaceholder);
@@ -118,9 +117,9 @@ export const toSpec = (root: Mdast.IRoot): SMdast.IRoot => {
             },
           ],
         };
-      }
 
-      continue;
+        continue;
+      }
     }
 
     if (inTab) {


### PR DESCRIPTION
Required for https://github.com/stoplightio/markdown-viewer/pull/14.