### PR TITLE
feat: markdown builder

### DIFF
--- a/src/__tests__/builder.spec.ts
+++ b/src/__tests__/builder.spec.ts
@@ -1,0 +1,32 @@
+import { Builder } from '../builder';
+
+describe('Builder', () => {
+  describe('#addMarkdown', () => {
+    it('takes any markdown, parses it and attaches to the root node', () => {
+      const b = new Builder();
+      const markdown = '**foo**\n\nwooo';
+      b.addMarkdown(markdown);
+      expect(b.toString()).toEqual(`${markdown}\n`);
+    });
+  });
+
+  describe('#addChild', () => {
+    it('takes any Mdast child and places it under the root node', () => {
+      const b = new Builder();
+
+      const node = {
+        type: 'heading',
+        depth: 1,
+        children: [
+          {
+            type: 'text',
+            value: 'Foo',
+          },
+        ],
+      };
+
+      b.addChild(node);
+      expect(b.toString()).toEqual('# Foo\n');
+    });
+  });
+});

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,0 +1,27 @@
+import * as Unist from 'unist';
+import { Reader } from './reader';
+import { ILangReader } from './reader/types';
+import { stringify } from './stringify';
+
+export class Builder {
+  public root: Unist.Parent;
+
+  constructor(public reader: ILangReader = new Reader()) {
+    this.root = {
+      type: 'root',
+      children: [],
+    };
+  }
+
+  public addMarkdown(markdown: string) {
+    this.root.children.push(...this.reader.fromLang(markdown).children);
+  }
+
+  public addChild(node: Unist.Node) {
+    this.root.children.push(node);
+  }
+
+  public toString() {
+    return stringify(this.root);
+  }
+}

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,10 +1,11 @@
 import * as Unist from 'unist';
+import { IRoot } from './ast-types/mdast';
 import { Reader } from './reader';
 import { ILangReader } from './reader/types';
 import { stringify } from './stringify';
 
 export class Builder {
-  public root: Unist.Parent;
+  public root: IRoot;
 
   constructor(public reader: ILangReader = new Reader()) {
     this.root = {


### PR DESCRIPTION
This might be particularly useful in `@stoplight/elements` where we build markdown out of strings and pass it to MarkdownViewer.

Ideally, we could use builder functions (or whatever this is called, see comment below), but I assumed it could introduce confusion, so chose a more developer friendly approach.

Example of 'builder functions'
https://github.com/mike-north/mdast-builder
https://github.com/benjamn/ast-types
https://babeljs.io/docs/en/babel-types

I liked the above approach more, as it's by far more flexible, but let's keep it simple for now.
