### PR TITLE
chore: exposed md ast types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './parseWithPointers';
 export * from './types';
 export * from './frontmatter';
 export * from './getters';
+export * from './ast-types/mdast';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from './types';
 export * from './frontmatter';
 export * from './getters';
 export * from './ast-types/mdast';
+export * from './reader';


### PR DESCRIPTION
1. Exposed md ast types in order. They are used in elements.
2. Exposed Reader - in is also used in elements (in MarkdownViewer and PageToc). Here I'm unsure whether it is good step. Thoughts?