### PR TITLE
fix: force release

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,5 @@ export * from './parseWithPointers';
 export * from './types';
 export * from './frontmatter';
 export * from './getters';
-export * from './ast-types/mdast';
 export * from './reader';
+export * from './ast-types/mdast';


### PR DESCRIPTION
Previous PR had `chore: ...` which did not triggered release to npm.