### PR TITLE
fix: ignore self-closing tags

### DIFF
--- a/src/plugins/__tests__/mergeHtml.spec.ts
+++ b/src/plugins/__tests__/mergeHtml.spec.ts
@@ -157,6 +157,52 @@ describe('merge HTML plugin', () => {
     });
   });
 
+  it('should ignore self-closing tags', () => {
+    const parsed = parse(`<input>foo<img>bar<img>`);
+
+    expect(
+      unified()
+        .use(mergeHtml)
+        .runSync(parsed),
+    ).toStrictEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'html',
+              value: '<input>',
+              position: expect.any(Object),
+            },
+            {
+              type: 'text',
+              value: 'foo',
+              position: expect.any(Object),
+            },
+            {
+              type: 'html',
+              value: '<img>',
+              position: expect.any(Object),
+            },
+            {
+              type: 'text',
+              value: 'bar',
+              position: expect.any(Object),
+            },
+            {
+              type: 'html',
+              value: '<img>',
+              position: expect.any(Object),
+            },
+          ],
+          position: expect.any(Object),
+        },
+      ],
+      position: expect.any(Object),
+    });
+  });
+
   it('should ignore any markdown inside block html element', () => {
     const parsed = parse(`<dl>
   <dt>Definition list</dt>

--- a/src/plugins/__tests__/mergeHtml.spec.ts
+++ b/src/plugins/__tests__/mergeHtml.spec.ts
@@ -158,7 +158,7 @@ describe('merge HTML plugin', () => {
   });
 
   it('should ignore self-closing tags', () => {
-    const parsed = parse(`<input>foo<img>bar<img>`);
+    const parsed = parse(`<input>foo<img>bar<img />foobar`);
 
     expect(
       unified()
@@ -192,7 +192,12 @@ describe('merge HTML plugin', () => {
             },
             {
               type: 'html',
-              value: '<img>',
+              value: '<img />',
+              position: expect.any(Object),
+            },
+            {
+              type: 'text',
+              value: 'foobar',
               position: expect.any(Object),
             },
           ],


### PR DESCRIPTION
Fixes https://github.com/stoplightio/platform-internal/issues/3351
We could also create a inlinehtml node without children
