### PR TITLE
feat: resolver plugin

### DIFF
--- a/src/ast-types/mdast.ts
+++ b/src/ast-types/mdast.ts
@@ -24,6 +24,7 @@ export interface IHeading extends Unist.Parent {
 export interface ICode extends Unist.Literal {
   type: 'code';
   lang?: string;
+  resolved?: null | object;
 }
 
 export interface IInlineCode extends Unist.Literal {

--- a/src/plugins/__tests__/__fixtures__/references.md
+++ b/src/plugins/__tests__/__fixtures__/references.md
@@ -29,7 +29,7 @@ be the http object to be rendered.
     },
     "query": {
       "page": 2
-     }
+    }
   }
 }
 ```

--- a/src/plugins/__tests__/__fixtures__/references.md
+++ b/src/plugins/__tests__/__fixtures__/references.md
@@ -17,9 +17,7 @@ definitions:
 A smd http try it out block is a smd code block with the `http` language tag. The contents of the code fence should
 be the http object to be rendered.
 
-<!-- type: http -->
-
-```http
+```json http
 {
   "request": {
     "method": "get",

--- a/src/plugins/__tests__/__fixtures__/references.md
+++ b/src/plugins/__tests__/__fixtures__/references.md
@@ -1,0 +1,48 @@
+# My article with $refs
+
+The beginning of an awesome article...
+
+```yaml json_schema
+type: object
+properties:
+  user:
+    $ref: #/definitions/User
+definitions:
+  User:
+    $ref: ../reference/models/user.v1.yaml
+```
+
+## HTTP Try It Out
+
+A smd http try it out block is a smd code block with the `http` language tag. The contents of the code fence should
+be the http object to be rendered.
+
+<!-- type: http -->
+
+```http
+{
+  "request": {
+    "method": "get",
+    "url": "https://next-api.stoplight.io/projects/45",
+    "headers": {
+      "$ref": "#/foo"
+    },
+    "query": {
+      "page": 2
+     }
+  }
+}
+```
+
+### Example response
+
+```json json_schema
+{
+  "type": "object",
+  "properties": {
+    "street": {
+      "$ref": "#/test"
+    }
+  }
+}
+```

--- a/src/plugins/__tests__/resolver.spec.ts
+++ b/src/plugins/__tests__/resolver.spec.ts
@@ -72,13 +72,10 @@ definitions:
           expect.objectContaining({
             type: 'paragraph',
           }),
-          expect.objectContaining({
-            type: 'html',
-          }),
           {
             type: 'code',
-            lang: 'http',
-            meta: null,
+            lang: 'json',
+            meta: 'http',
             value: `{
   "request": {
     "method": "get",
@@ -175,13 +172,10 @@ definitions:
           expect.objectContaining({
             type: 'paragraph',
           }),
-          expect.objectContaining({
-            type: 'html',
-          }),
           {
             type: 'code',
-            lang: 'http',
-            meta: null,
+            lang: 'json',
+            meta: 'http',
             value: `{
   "request": {
     "method": "get",
@@ -256,9 +250,7 @@ definitions:
         A smd http try it out block is a smd code block with the \`http\` language tag. The contents of the code fence should
         be the http object to be rendered.
 
-        <!-- type: http -->
-
-        \`\`\`http
+        \`\`\`json http
         {
           \\"request\\": {
             \\"method\\": \\"get\\",

--- a/src/plugins/__tests__/resolver.spec.ts
+++ b/src/plugins/__tests__/resolver.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import remarkStringify, { RemarkStringifyOptions } from 'remark-stringify';
 import unified from 'unified';
 import { parse } from '../../parse';
+import { stringify } from '../../stringify';
 import resolver from '../resolver';
 
 function replaceRefs(obj: object) {
@@ -229,6 +230,7 @@ definitions:
 
       const tree = await processor.run(parsed);
 
+      expect(processor.stringify(tree)).toEqual(stringify(tree));
       expect(processor.stringify(tree)).toMatchInlineSnapshot(`
         "# My article with $refs
 
@@ -294,6 +296,7 @@ definitions:
 
       const tree = await processor.run(JSON.parse(JSON.stringify(parsed)));
 
+      expect(processor.stringify(tree)).toEqual(stringify(tree));
       expect(processor.stringify(tree)).toEqual(
         unified()
           .use<RemarkStringifyOptions[]>(remarkStringify)

--- a/src/plugins/__tests__/resolver.spec.ts
+++ b/src/plugins/__tests__/resolver.spec.ts
@@ -1,0 +1,207 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import remarkStringify, { RemarkStringifyOptions } from 'remark-stringify';
+import unified from 'unified';
+import { parse } from '../../parse';
+import resolver from '../resolver';
+
+function replaceRefs(obj: object) {
+  for (const value of Object.values(obj)) {
+    if (typeof value !== 'object' || value === null) continue;
+    if ('$ref' in value) {
+      value.$ref = '<replaced>';
+    } else {
+      replaceRefs({ ...value });
+    }
+  }
+
+  return obj;
+}
+
+describe('Resolver plugin', () => {
+  describe('parsing', () => {
+    it('should resolve $refs for json_schema & http', async () => {
+      const parsed = parse(fs.readFileSync(path.join(__dirname, '__fixtures__/references.md'), 'utf8'));
+
+      expect(
+        await unified()
+          .use(resolver, {
+            async resolver(node, data) {
+              return replaceRefs({ ...data });
+            },
+          })
+          .run(parsed),
+      ).toStrictEqual({
+        type: 'root',
+        children: [
+          expect.objectContaining({
+            type: 'heading',
+          }),
+          expect.objectContaining({
+            type: 'paragraph',
+          }),
+          {
+            type: 'code',
+            lang: 'yaml',
+            meta: 'json_schema',
+            value: `type: object
+properties:
+  user:
+    $ref: #/definitions/User
+definitions:
+  User:
+    $ref: ../reference/models/user.v1.yaml`,
+            resolved: {
+              type: 'object',
+              properties: {
+                user: {
+                  $ref: '<replaced>',
+                },
+              },
+              definitions: {
+                User: {
+                  $ref: '<replaced>',
+                },
+              },
+            },
+            position: expect.any(Object),
+          },
+          expect.objectContaining({
+            type: 'heading',
+          }),
+          expect.objectContaining({
+            type: 'paragraph',
+          }),
+          expect.objectContaining({
+            type: 'html',
+          }),
+          {
+            type: 'code',
+            lang: 'http',
+            meta: null,
+            value: `{
+  "request": {
+    "method": "get",
+    "url": "https://next-api.stoplight.io/projects/45",
+    "headers": {
+      "$ref": "#/foo"
+    },
+    "query": {
+      "page": 2
+     }
+  }
+}`,
+            resolved: {
+              request: {
+                method: 'get',
+                url: 'https://next-api.stoplight.io/projects/45',
+                headers: {
+                  $ref: '<replaced>',
+                },
+                query: {
+                  page: 2,
+                },
+              },
+            },
+            position: expect.any(Object),
+          },
+          expect.objectContaining({
+            type: 'heading',
+          }),
+          {
+            type: 'code',
+            lang: 'json',
+            meta: 'json_schema',
+            resolved: {
+              type: 'object',
+              properties: {
+                street: {
+                  $ref: '<replaced>',
+                },
+              },
+            },
+            value: `{
+  "type": "object",
+  "properties": {
+    "street": {
+      "$ref": "#/test"
+    }
+  }
+}`,
+            position: expect.any(Object),
+          },
+        ],
+        position: expect.any(Object),
+      });
+    });
+  });
+
+  describe('stringifying', () => {
+    it('should dump resolved blocks', async () => {
+      const parsed = parse(fs.readFileSync(path.join(__dirname, '__fixtures__/references.md'), 'utf8'));
+
+      const processor = await unified()
+        .use<RemarkStringifyOptions[]>(remarkStringify)
+        .use(resolver, {
+          async resolver(node, data) {
+            return replaceRefs({ ...data });
+          },
+        });
+
+      const tree = await processor.run(parsed);
+
+      expect(processor.stringify(tree)).toMatchInlineSnapshot(`
+        "# My article with $refs
+
+        The beginning of an awesome article...
+
+        \`\`\`yaml json_schema
+        type: object
+        properties:
+          user:
+            $ref: <replaced>
+        definitions:
+          User:
+            $ref: <replaced>
+
+        \`\`\`
+
+        ## HTTP Try It Out
+
+        A smd http try it out block is a smd code block with the \`http\` language tag. The contents of the code fence should
+        be the http object to be rendered.
+
+        <!-- type: http -->
+
+        \`\`\`http
+        {
+          \\"request\\": {
+            \\"method\\": \\"get\\",
+            \\"url\\": \\"https://next-api.stoplight.io/projects/45\\",
+            \\"headers\\": {
+              \\"$ref\\": \\"<replaced>\\"
+            },
+            \\"query\\": {
+              \\"page\\": 2
+            }
+          }
+        }
+        \`\`\`
+
+        ### Example response
+
+        \`\`\`json json_schema
+        {
+          \\"type\\": \\"object\\",
+          \\"properties\\": {
+            \\"street\\": {
+              \\"$ref\\": \\"<replaced>\\"
+            }
+          }
+        }
+        \`\`\`
+        "
+      `);
+    });
+  });
+});

--- a/src/plugins/resolver.ts
+++ b/src/plugins/resolver.ts
@@ -3,10 +3,9 @@ import { parse, safeStringify } from '@stoplight/yaml';
 import * as remarkStringify from 'remark-stringify';
 import * as unified from 'unified';
 import visit from 'unist-util-visit';
-import { ICode as IMDAstCode } from '../ast-types/mdast';
-import { ICode as ISMDAstCode } from '../ast-types/smdast';
+import { ICode } from '../ast-types/mdast';
 
-type Resolver = (node: IMDAstCode, data: Dictionary<unknown>) => Promise<object>;
+type Resolver = (node: ICode, data: Dictionary<unknown>) => Promise<object>;
 
 export default function(this: unified.Processor, { resolver }: { resolver: Resolver }): unified.Transformer {
   const { Compiler } = this;
@@ -22,7 +21,7 @@ export default function(this: unified.Processor, { resolver }: { resolver: Resol
   };
 }
 
-const createVisitor = (resolver: Resolver, promises: Array<Promise<void>>): visit.Visitor<IMDAstCode> => node => {
+const createVisitor = (resolver: Resolver, promises: Array<Promise<void>>): visit.Visitor<ICode> => node => {
   if (typeof node.value !== 'string') return;
   if (node.meta !== 'json_schema' && node.lang !== 'http') return;
 
@@ -30,14 +29,14 @@ const createVisitor = (resolver: Resolver, promises: Array<Promise<void>>): visi
     promises.push(
       resolver(node, parse(node.value))
         .then(resolved => {
-          (node as ISMDAstCode).resolved = resolved;
+          node.resolved = resolved;
         })
         .catch(() => {
-          (node as ISMDAstCode).resolved = null;
+          node.resolved = null;
         }),
     );
   } catch {
-    (node as ISMDAstCode).resolved = null;
+    node.resolved = null;
   }
 };
 

--- a/src/plugins/resolver.ts
+++ b/src/plugins/resolver.ts
@@ -23,7 +23,7 @@ export default function(this: unified.Processor, { resolver }: { resolver: Resol
 
 const createVisitor = (resolver: Resolver, promises: Array<Promise<void>>): visit.Visitor<ICode> => node => {
   if (typeof node.value !== 'string') return;
-  if (node.meta !== 'json_schema' && node.lang !== 'http') return;
+  if (node.meta !== 'json_schema' && node.meta !== 'http') return;
 
   try {
     promises.push(
@@ -50,9 +50,7 @@ function createCompiler(
         {
           ...node,
           value:
-            node.lang === 'json' || node.lang === 'http'
-              ? JSON.stringify(node.resolved, null, 2)
-              : safeStringify(node.resolved, { indent: 2 }),
+            node.lang === 'json' ? JSON.stringify(node.resolved, null, 2) : safeStringify(node.resolved, { indent: 2 }),
         },
         parent,
       );

--- a/src/plugins/resolver.ts
+++ b/src/plugins/resolver.ts
@@ -1,0 +1,64 @@
+import { Dictionary } from '@stoplight/types';
+import { parse, safeStringify } from '@stoplight/yaml';
+import * as remarkStringify from 'remark-stringify';
+import * as unified from 'unified';
+import visit from 'unist-util-visit';
+import { ICode as IMDAstCode } from '../ast-types/mdast';
+import { ICode as ISMDAstCode } from '../ast-types/smdast';
+
+type Resolver = (node: IMDAstCode, data: Dictionary<unknown>) => Promise<object>;
+
+export default function(this: unified.Processor, { resolver }: { resolver: Resolver }): unified.Transformer {
+  const { Compiler } = this;
+
+  if (Compiler !== void 0) {
+    Compiler.prototype.visitors.code = createCompiler(Compiler.prototype.visitors.code);
+  }
+
+  return async tree => {
+    const promises: Array<Promise<void>> = [];
+    visit(tree, 'code', createVisitor(resolver, promises));
+    await Promise.all(promises);
+  };
+}
+
+const createVisitor = (resolver: Resolver, promises: Array<Promise<void>>): visit.Visitor<IMDAstCode> => node => {
+  if (typeof node.value !== 'string') return;
+  if (node.meta !== 'json_schema' && node.lang !== 'http') return;
+
+  try {
+    promises.push(
+      resolver(node, parse(node.value))
+        .then(resolved => {
+          (node as ISMDAstCode).resolved = resolved;
+        })
+        .catch(() => {
+          (node as ISMDAstCode).resolved = null;
+        }),
+    );
+  } catch {
+    (node as ISMDAstCode).resolved = null;
+  }
+};
+
+function createCompiler(
+  fn: typeof remarkStringify.Compiler['prototype']['visitors']['code'],
+): typeof remarkStringify.Compiler['prototype']['visitors']['code'] {
+  return function(this: remarkStringify.Compiler, node, parent) {
+    if (node.type === 'code' && 'resolved' in node && node.resolved !== null) {
+      return fn.call(
+        this,
+        {
+          ...node,
+          value:
+            node.lang === 'json' || node.lang === 'http'
+              ? JSON.stringify(node.resolved, null, 2)
+              : safeStringify(node.resolved, { indent: 2 }),
+        },
+        parent,
+      );
+    }
+
+    return fn.call(this, node, parent);
+  };
+}

--- a/src/plugins/resolver.ts
+++ b/src/plugins/resolver.ts
@@ -7,18 +7,20 @@ import { ICode } from '../ast-types/mdast';
 
 type Resolver = (node: ICode, data: Dictionary<unknown>) => Promise<object>;
 
-export default function(this: unified.Processor, { resolver }: { resolver: Resolver }): unified.Transformer {
+export default function(this: unified.Processor, opts?: { resolver: Resolver }): unified.Transformer | void {
   const { Compiler } = this;
 
   if (Compiler !== void 0) {
     Compiler.prototype.visitors.code = createCompiler(Compiler.prototype.visitors.code);
   }
 
-  return async tree => {
-    const promises: Array<Promise<void>> = [];
-    visit(tree, 'code', createVisitor(resolver, promises));
-    await Promise.all(promises);
-  };
+  if (opts?.resolver) {
+    return async tree => {
+      const promises: Array<Promise<void>> = [];
+      visit(tree, 'code', createVisitor(opts.resolver, promises));
+      await Promise.all(promises);
+    };
+  }
 }
 
 const createVisitor = (resolver: Resolver, promises: Array<Promise<void>>): visit.Visitor<ICode> => node => {

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -15,11 +15,7 @@ const defaultProcessor = unified()
   .use<RemarkStringifyOptions[]>(remarkStringify)
   .use(jiraBlocks)
   .use(frontmatter, ['yaml'])
-  .use(resolver, {
-    async resolver() {
-      return {};
-    },
-  });
+  .use(resolver);
 
 export const stringify = (
   tree: Node,

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -2,6 +2,7 @@ import remarkStringify, { RemarkStringifyOptions } from 'remark-stringify';
 import unified from 'unified';
 import { Node } from 'unist';
 import jiraBlocks from './plugins/jiraBlocks';
+import resolver from './plugins/resolver';
 const frontmatter = require('remark-frontmatter');
 
 const defaultOpts: Partial<RemarkStringifyOptions> = {
@@ -13,7 +14,12 @@ const defaultOpts: Partial<RemarkStringifyOptions> = {
 const defaultProcessor = unified()
   .use<RemarkStringifyOptions[]>(remarkStringify)
   .use(jiraBlocks)
-  .use(frontmatter, ['yaml']);
+  .use(frontmatter, ['yaml'])
+  .use(resolver, {
+    async resolver() {
+      return {};
+    },
+  });
 
 export const stringify = (
   tree: Node,


### PR DESCRIPTION
Needed by https://github.com/stoplightio/platform-internal/pull/4861 for https://github.com/stoplightio/platform-internal/issues/3985

It doesn't support the legacy (I suppose?) syntax based on HTML comment, such as `<!-- type: http -->`
I can cover that particular scenario, but I am not quite sure whether we still aim to maintain it.