### PR TITLE
feat: export markdown builder

### DIFF
--- a/src/ast-types/mdast.ts
+++ b/src/ast-types/mdast.ts
@@ -232,6 +232,10 @@ export type TabsContent = Tab;
 
 export interface Tab extends Parent {
   type: 'tab';
+
+  annotations?: {
+    title?: String;
+  };
 }
 
 export interface CodeGroup extends Parent<Code> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './ast-types';
+export * from './builder';
 export * from './frontmatter';
 export * from './getJsonPathForNode';
 export * from './getJsonPathForPosition';

--- a/src/plugins/stringify/blockquote.ts
+++ b/src/plugins/stringify/blockquote.ts
@@ -3,10 +3,15 @@ import { Handler } from 'mdast-util-to-markdown';
 // @ts-expect-error
 import blockquote from 'mdast-util-to-markdown/lib/handle/blockquote';
 
+import { MDAST } from '../../ast-types';
+
 const { safeStringify } = Yaml;
 
 export const blockquoteHandler: Handler = function (node, _, context) {
-  const annotations = (node.data?.hProperties || {}) as any;
+  const annotations = {
+    ...(node.annotations as MDAST.Blockquote['annotations']),
+    ...(node.data?.hProperties as MDAST.Blockquote['annotations']),
+  };
 
   const value = blockquote(node, _, context);
 
@@ -14,7 +19,7 @@ export const blockquoteHandler: Handler = function (node, _, context) {
     return `<!-- ${safeStringify(annotations, { skipInvalid: true }).trim()} -->
 
 ${value}`;
-  } else {
-    return value;
   }
+
+  return value;
 };

--- a/src/plugins/stringify/code.ts
+++ b/src/plugins/stringify/code.ts
@@ -3,6 +3,8 @@ import { Handler } from 'mdast-util-to-markdown';
 // @ts-expect-error
 import code from 'mdast-util-to-markdown/lib/handle/code';
 
+import { MDAST } from '../../ast-types';
+
 const { safeStringify } = Yaml;
 
 export const codeHandler: Handler = function (node, _, context) {
@@ -14,7 +16,7 @@ export const codeHandler: Handler = function (node, _, context) {
       node.lang === 'json' ? JSON.stringify(node.resolved, null, 2) : safeStringify(node.resolved, { indent: 2 });
   }
 
-  const metaProps = computeMetaProps(annotations);
+  const metaProps = computeMetaProps({ ...(node.annotations as MDAST.Code['annotations']), ...annotations });
   if (metaProps.length) {
     node.meta = metaProps.join(' ');
   }

--- a/src/plugins/stringify/tabs.ts
+++ b/src/plugins/stringify/tabs.ts
@@ -3,6 +3,8 @@ import { Handler } from 'mdast-util-to-markdown';
 // @ts-expect-error
 import flow from 'mdast-util-to-markdown/lib/util/container-flow';
 
+import { MDAST } from '../../ast-types';
+
 const { safeStringify } = Yaml;
 
 export const tabsHandler: Handler = function (node, _, context) {
@@ -25,7 +27,7 @@ export const tabHandler: Handler = function (node, _, context) {
 
   return `<!--
 type: tab
-${safeStringify(annotations, { skipInvalid: true }).trim()}
+${safeStringify({ ...(node.annotations as MDAST.Tab['annotations']), ...annotations }, { skipInvalid: true }).trim()}
 -->
 
 ${value}`;


### PR DESCRIPTION
- Exports builder
- Handles annotations included by builder's `addChild` method