### PR TITLE
fix: export plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './getLocationForJsonPath';
 export * from './getters';
 export * from './parse';
 export * from './parseWithPointers';
+export * from './plugins/run';
 export * from './reader';
 export * from './stringify';
 export * from './types';


### PR DESCRIPTION
Needed to use `resolveCodeBlocks` in Studio if we want to address https://github.com/stoplightio/platform-internal/pull/9586#discussion_r792934408