### PR TITLE
feat: getTitle supports raw strings now

### DIFF
--- a/src/getters/__tests__/get-title.test.ts
+++ b/src/getters/__tests__/get-title.test.ts
@@ -1,52 +1,103 @@
 import { parse } from '../../parse';
 import { getTitle } from '../get-title';
 
-describe('get-title', () => {
-  it('should return frontmatter title if present', () => {
-    const title = getTitle(
-      parse(`---
+const titleInFrontMatter = `---
 title: hello
 ---
 
 # Other Title
 
 Yo
-`),
-    );
+`;
 
-    expect(title).toBe('hello');
-  });
-
-  it('should return heading if present', () => {
-    const title = getTitle(
-      parse(`---
+const titleInH1 = `---
 summary: what it is about
 ---
 
 # Other Title
 
 Yo
-`),
-    );
+`;
 
-    expect(title).toBe('Other Title');
-  });
+const titleInUnderlineH1 = `---
+summary: what it is about
+---
 
-  it('should return headings other than h1 if present', () => {
-    const title = getTitle(
-      parse(`what it is about
+Other Title
+===========
+
+Yo
+`;
+
+const titleInH2 = `what it is about
 
 ## Other Title 2
 
 Yo
-`),
-    );
+`;
 
-    expect(title).toBe('Other Title 2');
+const noTitle = `what it is about`;
+
+describe('get-title', () => {
+  describe('parsed', () => {
+    it('should return frontmatter title if present', () => {
+      const title = getTitle(parse(titleInFrontMatter));
+
+      expect(title).toBe('hello');
+    });
+
+    it('should return # heading if present', () => {
+      const title = getTitle(parse(titleInH1));
+
+      expect(title).toBe('Other Title');
+    });
+
+    it('should return underlined heading if present', () => {
+      const title = getTitle(parse(titleInUnderlineH1));
+
+      expect(title).toBe('Other Title');
+    });
+
+    it('should return headings other than h1 if present', () => {
+      const title = getTitle(parse(titleInH2));
+
+      expect(title).toBe('Other Title 2');
+    });
+
+    it('should return undefined if no frontmatter title and no headings', () => {
+      const title = getTitle(parse(noTitle));
+      expect(title).toBe(undefined);
+    });
   });
 
-  it('should return undefined if no frontmatter title and no headings', () => {
-    const title = getTitle(parse(`what it is about`));
-    expect(title).toBe(undefined);
+  describe('raw string', () => {
+    it('should return frontmatter title if present', () => {
+      const title = getTitle(titleInFrontMatter);
+
+      expect(title).toBe('hello');
+    });
+
+    it('should return # heading if present', () => {
+      const title = getTitle(titleInH1);
+
+      expect(title).toBe('Other Title');
+    });
+
+    it('should not detect underlined headings, sorry not sorry', () => {
+      const title = getTitle(titleInUnderlineH1);
+
+      expect(title).toBe(undefined);
+    });
+
+    it('should return headings other than h1 if present', () => {
+      const title = getTitle(titleInH2);
+
+      expect(title).toBe('Other Title 2');
+    });
+
+    it('should return undefined if no frontmatter title and no headings', () => {
+      const title = getTitle(noTitle);
+      expect(title).toBe(undefined);
+    });
   });
 });

--- a/src/getters/get-title.ts
+++ b/src/getters/get-title.ts
@@ -1,7 +1,31 @@
 import { MDAST } from '../ast-types';
+import { Frontmatter } from '../frontmatter';
 import { getProperty } from './get-property';
 
 // Priority: yaml title, then first heading
-export const getTitle = (data?: MDAST.Root) => {
-  return getProperty('title', 'heading', data);
+export const getTitle = (data?: MDAST.Root | string) => {
+  if (typeof data === 'string') {
+    return getTitleFromRaw(data);
+  } else {
+    return getProperty('title', 'heading', data);
+  }
 };
+
+function getTitleFromRaw(raw?: string) {
+  if (!raw) return raw;
+
+  const frontmatterBlock = Frontmatter.getFrontmatterBlock(raw);
+
+  if (frontmatterBlock) {
+    const title = new Frontmatter(frontmatterBlock).get('title');
+    if (title) {
+      return String(title);
+    }
+  }
+
+  // Note: This only supports #-style headings, but underlined headings are much rarer
+  // Sonar Cloud flagged the original version /^#+\s*(.*)$/m as super-linear, so it has
+  // become this rather nasty regex to emulate atomic groups / possessive qualifiers.
+  const match = raw?.match(/^(?=(#+))\1(?=(\s*))\2(?=(.*))\3$/m);
+  return match ? match[3] : void 0;
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/stoplightio/platform-internal/issues/2837

The Studio Search dialog displays result titles for Articles, but we don't parse all the Markdown files during activation (the lazy parsing optimization) so we need to be able to extract the title without a full parse for consistency. The lack of consistency has resulted in flaky tests on the Search results dialog.

## Description
<!-- Describe your technical changes in detail. -->
Support grabbing title from frontmatter and headings for unparsed markdown files.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
I added tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
